### PR TITLE
Fix issues with server restarts from various client commands.

### DIFF
--- a/BedrockService/BedrockService.Shared/Classes/ServerInfo.cs
+++ b/BedrockService/BedrockService.Shared/Classes/ServerInfo.cs
@@ -28,6 +28,7 @@ namespace BedrockService.Shared.Classes {
             FileName = "Dedicated Server.conf";
             ServerPath = new Property("ServerPath", $@"{ServersPath}\{ServerName}");
             ServerExeName = new Property("ServerExeName", $"BedrockService.{ServerName}.exe");
+            ServerPropList.Clear();
             _defaultPropList.ForEach(p =>  ServerPropList.Add(new Property(p.KeyName, p.DefaultValue)));
             return true;
         }

--- a/BedrockService/BedrockService.Shared/Classes/ServiceInfo.cs
+++ b/BedrockService/BedrockService.Shared/Classes/ServiceInfo.cs
@@ -40,6 +40,7 @@ namespace BedrockService.Shared.Classes {
             globals.Add(new Property("UpdateCron", "0 2 * * *"));
             globals.Add(new Property("LogServerOutput", "true"));
             globals.Add(new Property("LogApplicationOutput", "true"));
+            _defaultServerProps.Clear();
             try {
                 File.ReadAllLines($@"{_processInfo.GetDirectory()}\Server\stock_props.conf")
                    .ToList()

--- a/BedrockService/Client/Forms/MainWindow.cs
+++ b/BedrockService/Client/Forms/MainWindow.cs
@@ -20,7 +20,6 @@ namespace BedrockService.Client.Forms {
         public IClientSideServiceConfiguration clientSideServiceConfiguration;
         public bool ShowsSvcLog = false;
         public bool ServerBusy = false;
-        private PropEditorForm _editDialog;
         private int _connectTimeout;
         private bool _followTail = false;
         private bool _blockConnect = false;
@@ -243,15 +242,15 @@ namespace BedrockService.Client.Forms {
         }
 
         private void EditCfg_Click(object sender, EventArgs e) {
-            _editDialog = new PropEditorForm();
-            _editDialog.PopulateBoxes(selectedServer.GetAllProps());
-            if (_editDialog.ShowDialog() == DialogResult.OK) {
-                JsonSerializerSettings settings = new() { TypeNameHandling = TypeNameHandling.All };
-                byte[] serializeToBytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(_editDialog.workingProps, Formatting.Indented, settings));
-                FormManager.TCPClient.SendData(serializeToBytes, NetworkMessageSource.Client, NetworkMessageDestination.Server, connectedHost.GetServerIndex(selectedServer), NetworkMessageTypes.PropUpdate);
-                selectedServer.SetAllProps(_editDialog.workingProps);
-                _editDialog.Close();
-                _editDialog.Dispose();
+            using (PropEditorForm _editDialog = new PropEditorForm()) {
+                DisableUI();
+                _editDialog.PopulateBoxes(selectedServer.GetAllProps());
+                if (_editDialog.ShowDialog() == DialogResult.OK) {
+                    JsonSerializerSettings settings = new() { TypeNameHandling = TypeNameHandling.All };
+                    byte[] serializeToBytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(_editDialog.workingProps, Formatting.Indented, settings));
+                    FormManager.TCPClient.SendData(serializeToBytes, NetworkMessageSource.Client, NetworkMessageDestination.Server, connectedHost.GetServerIndex(selectedServer), NetworkMessageTypes.PropUpdate);
+                    selectedServer.SetAllProps(_editDialog.workingProps);
+                }
             }
         }
 
@@ -261,17 +260,16 @@ namespace BedrockService.Client.Forms {
         }
 
         private void EditGlobals_Click(object sender, EventArgs e) {
-            _editDialog = new PropEditorForm();
-            _editDialog.PopulateBoxes(connectedHost.GetAllProps());
-            if (_editDialog.ShowDialog() == DialogResult.OK) {
-                JsonSerializerSettings settings = new() { TypeNameHandling = TypeNameHandling.All };
-                byte[] serializeToBytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(_editDialog.workingProps, Formatting.Indented, settings));
-                FormManager.TCPClient.SendData(serializeToBytes, NetworkMessageSource.Client, NetworkMessageDestination.Service, NetworkMessageTypes.PropUpdate);
-                connectedHost.SetAllProps(_editDialog.workingProps);
-                ServerBusy = true;
-                DisableUI();
-                _editDialog.Close();
-                _editDialog.Dispose();
+            using (PropEditorForm _editDialog = new PropEditorForm()) {
+                _editDialog.PopulateBoxes(connectedHost.GetAllProps());
+                if (_editDialog.ShowDialog() == DialogResult.OK) {
+                    JsonSerializerSettings settings = new() { TypeNameHandling = TypeNameHandling.All };
+                    byte[] serializeToBytes = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(_editDialog.workingProps, Formatting.Indented, settings));
+                    FormManager.TCPClient.SendData(serializeToBytes, NetworkMessageSource.Client, NetworkMessageDestination.Service, NetworkMessageTypes.PropUpdate);
+                    connectedHost.SetAllProps(_editDialog.workingProps);
+                    ServerBusy = true;
+                    DisableUI();
+                }
             }
         }
 
@@ -284,6 +282,7 @@ namespace BedrockService.Client.Forms {
             if (clientSideServiceConfiguration == null) {
                 clientSideServiceConfiguration = _configManager.HostConnectList.First(host => host.GetHostName() == HostListBox.Text);
             }
+            DisableUI();
             AddNewServerForm newServerForm = new AddNewServerForm(clientSideServiceConfiguration, connectedHost.GetServerList());
             if (newServerForm.ShowDialog() == DialogResult.OK) {
                 JsonSerializerSettings settings = new() { TypeNameHandling = TypeNameHandling.All };

--- a/BedrockService/Client/Networking/TCPClient.cs
+++ b/BedrockService/Client/Networking/TCPClient.cs
@@ -109,6 +109,7 @@ namespace BedrockService.Client.Networking {
                                         FormManager.MainWindow.connectedHost = JsonConvert.DeserializeObject<IServiceConfiguration>(data, settings);
                                         Connected = true;
                                         FormManager.MainWindow.RefreshServerContents();
+                                        FormManager.MainWindow.ServerBusy = false;
                                     }
                                 } catch (Exception e) {
                                     _logger.AppendLine($"Error: ConnectMan reported error: {e.Message}\n{e.StackTrace}");

--- a/BedrockService/Service/Management/ConfigManager.cs
+++ b/BedrockService/Service/Management/ConfigManager.cs
@@ -92,7 +92,6 @@ namespace BedrockService.Service.Management {
                 if (entry.StartsWith("#") || string.IsNullOrWhiteSpace(entry))
                     continue;
                 string[] split = entry.Split(',');
-                _logger.AppendLine($"Server \"{server.GetServerName()}\" Loaded registered player: {split[1]}");
                 IPlayer playerFound = server.GetPlayerByXuid(split[0]);
                 if (playerFound == null) {
                     server.AddUpdatePlayer(new Player(split[0], split[1], DateTime.Now.Ticks.ToString(), "0", "0", split[3].ToLower() == "true", split[2], split[4].ToLower() == "true"));
@@ -167,7 +166,6 @@ namespace BedrockService.Service.Management {
                 if (entry.StartsWith("#") || string.IsNullOrWhiteSpace(entry))
                     continue;
                 string[] split = entry.Split(',');
-                _logger.AppendLine($"Server \"{server.GetServerName()}\" loaded known player: {split[1]}");
                 IPlayer playerFound = server.GetPlayerByXuid(split[0]);
                 if (playerFound == null) {
                     server.AddUpdatePlayer(new Player(split[0], split[1], split[2], split[3], split[4], false, server.GetProp("default-player-permission-level").ToString(), false));

--- a/BedrockService/Service/Networking/NetworkStrategyLookup.cs
+++ b/BedrockService/Service/Networking/NetworkStrategyLookup.cs
@@ -134,7 +134,7 @@ namespace BedrockService.Service.Networking {
                 }
                 _serviceConfiguration.GetServerInfoByIndex(serverIndex).SetAllProps(propList);
                 _configurator.SaveServerProps(_serviceConfiguration.GetServerInfoByIndex(serverIndex), true);
-                _bedrockService.GetBedrockServerByIndex(serverIndex).RestartServer();
+                _bedrockService.GetBedrockServerByIndex(serverIndex).RestartServer().Wait();
                 return (Array.Empty<byte>(), 0, NetworkMessageTypes.UICallback);
             }
         }
@@ -148,7 +148,7 @@ namespace BedrockService.Service.Networking {
             }
 
             public (byte[] data, byte srvIndex, NetworkMessageTypes type) ParseMessage(byte[] data, byte serverIndex) {
-                _service.GetBedrockServerByIndex(serverIndex).RestartServer();
+                _service.GetBedrockServerByIndex(serverIndex).RestartServer().Wait();
                 return (Array.Empty<byte>(), 0, NetworkMessageTypes.UICallback);
             }
         }
@@ -373,7 +373,7 @@ namespace BedrockService.Service.Networking {
                 List<StartCmdEntry> entries = JsonConvert.DeserializeObject<List<StartCmdEntry>>(Encoding.UTF8.GetString(data, 5, data.Length - 5), settings);
                 _serviceConfiguration.GetServerInfoByIndex(serverIndex).SetStartCommands(entries);
                 _configurator.SaveServerProps(_serviceConfiguration.GetServerInfoByIndex(serverIndex), true);
-                return (Array.Empty<byte>(), 0, 0);
+                return (Array.Empty<byte>(), 0, NetworkMessageTypes.UICallback);
             }
         }
 

--- a/BedrockService/Service/Server/BedrockServer.cs
+++ b/BedrockService/Service/Server/BedrockServer.cs
@@ -287,26 +287,16 @@ namespace BedrockService.Service.Server {
                         _logger.AppendLine($"Server {GetServerName()} received quit signal.");
                         _AwaitingStopSignal = false;
                     }
-                    if (dataMsg.StartsWith("[INFO] Player connected")) {
-                        int usernameStart = dataMsg.IndexOf(':') + 2;
-                        int usernameEnd = dataMsg.IndexOf(',');
-                        int usernameLength = usernameEnd - usernameStart;
-                        int xuidStart = dataMsg.IndexOf(':', usernameEnd) + 2;
-                        string username = dataMsg.Substring(usernameStart, usernameLength);
-                        string xuid = dataMsg.Substring(xuidStart, dataMsg.Length - xuidStart);
-                        _logger.AppendLine($"Player {username} connected with XUID: {xuid}");
-                        _playerManager.PlayerConnected(username, xuid);
+                    if (dataMsg.Contains("Player connected")) {
+                        var playerInfo = ExtractPlayerInfoFromString(dataMsg);
+                        _logger.AppendLine($"Player {playerInfo.username} connected with XUID: {playerInfo.xuid}");
+                        _playerManager.PlayerConnected(playerInfo.username, playerInfo.xuid);
                         _configurator.SaveKnownPlayerDatabase(_serverConfiguration);
                     }
-                    if (dataMsg.StartsWith("[INFO] Player disconnected")) {
-                        int usernameStart = dataMsg.IndexOf(':') + 2;
-                        int usernameEnd = dataMsg.IndexOf(',');
-                        int usernameLength = usernameEnd - usernameStart;
-                        int xuidStart = dataMsg.IndexOf(':', usernameEnd) + 2;
-                        string username = dataMsg.Substring(usernameStart, usernameLength);
-                        string xuid = dataMsg.Substring(xuidStart, dataMsg.Length - xuidStart);
-                        _logger.AppendLine($"Player {username} disconnected with XUID: {xuid}");
-                        _playerManager.PlayerDisconnected(xuid);
+                    if (dataMsg.Contains("Player disconnected")) {
+                        var playerInfo = ExtractPlayerInfoFromString(dataMsg);
+                        _logger.AppendLine($"Player {playerInfo.username} disconnected with XUID: {playerInfo.xuid}");
+                        _playerManager.PlayerDisconnected(playerInfo.xuid);
                         _configurator.SaveKnownPlayerDatabase(_serverConfiguration);
                     }
                     if (dataMsg.Contains("Failed to load Vanilla")) {
@@ -341,6 +331,15 @@ namespace BedrockService.Service.Server {
                     }
                 }
             }
+        }
+
+        private static (string username, string xuid) ExtractPlayerInfoFromString (string dataMsg) {
+            int msgStartIndex = dataMsg.IndexOf(']') + 2;
+            int usernameStart = dataMsg.IndexOf(':', msgStartIndex) + 2;
+            int usernameEnd = dataMsg.IndexOf(',', usernameStart);
+            int usernameLength = usernameEnd - usernameStart;
+            int xuidStart = dataMsg.IndexOf(':', usernameEnd) + 2;
+            return (dataMsg.Substring(usernameStart, usernameLength), dataMsg.Substring(xuidStart, dataMsg.Length - xuidStart));
         }
 
         private void RunStartupCommands() {

--- a/BedrockService/Service/Server/BedrockServer.cs
+++ b/BedrockService/Service/Server/BedrockServer.cs
@@ -186,9 +186,11 @@ namespace BedrockService.Service.Server {
             });
         }
 
-        public void RestartServer() {
-            AwaitableServerStop(false).Wait();
-            AwaitableServerStart().Wait(); 
+        public Task RestartServer() {
+            return Task.Run(() => {
+                AwaitableServerStop(false).Wait();
+                AwaitableServerStart().Wait();
+            });
         }
 
         private Task RunServer() {
@@ -333,7 +335,7 @@ namespace BedrockService.Service.Server {
             }
         }
 
-        private static (string username, string xuid) ExtractPlayerInfoFromString (string dataMsg) {
+        private (string username, string xuid) ExtractPlayerInfoFromString (string dataMsg) {
             int msgStartIndex = dataMsg.IndexOf(']') + 2;
             int usernameStart = dataMsg.IndexOf(':', msgStartIndex) + 2;
             int usernameEnd = dataMsg.IndexOf(',', usernameStart);

--- a/BedrockService/Service/Server/IBedrockServer.cs
+++ b/BedrockService/Service/Server/IBedrockServer.cs
@@ -8,7 +8,7 @@ namespace BedrockService.Service.Server {
         Task AwaitableServerStop(bool stopWatchdog);
         string GetServerName();
         void WriteToStandardIn(string command);
-        void RestartServer();
+        Task RestartServer();
         bool RollbackToBackup(byte serverIndex, string folderName);
         void InitializeBackup();
         IBedrockLogger GetLogger();

--- a/BedrockService/Service/Server/Management/PlayerManager.cs
+++ b/BedrockService/Service/Server/Management/PlayerManager.cs
@@ -7,12 +7,13 @@
         }
 
         public void PlayerConnected(string username, string xuid) {
+            string currentTimeInTicks = DateTime.Now.Ticks.ToString();
             IPlayer playerFound = _serverConfiguration.GetPlayerByXuid(xuid);
             if (playerFound == null) {
-                _serverConfiguration.AddUpdatePlayer(new Player(xuid, username, DateTime.Now.Ticks.ToString(), "0", "0", false, _serverConfiguration.GetProp("default-player-permission-level").ToString(), false));
+                _serverConfiguration.AddUpdatePlayer(new Player(xuid, username, currentTimeInTicks, currentTimeInTicks, "0", false, _serverConfiguration.GetProp("default-player-permission-level").ToString(), false));
                 return;
             }
-            playerFound.UpdateTimes(DateTime.Now.Ticks.ToString(), playerFound.GetTimes().Disconn);
+            playerFound.UpdateTimes(currentTimeInTicks, playerFound.GetTimes().Disconn);
             _serverConfiguration.AddUpdatePlayer(playerFound);
         }
 


### PR DESCRIPTION
This new build will fix a few features with odd timing of serverside events, as well as UI unlocking. Found and fixed a few bugs with PlayerManager not registering new players since Bedrock Server 1.18+ changed logs to include timestamps throughout the entire log output, unlike before.